### PR TITLE
Revamp landing page styling to match hero aesthetic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,12 @@ import { Footer } from "./components/Footer";
 
 export default function App() {
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-[#04191d] via-[#062b32] to-[#0b3d45] text-foreground">
+    <div className="min-h-screen flex flex-col bg-[#05060f] text-slate-100">
+      <div className="pointer-events-none fixed inset-0 -z-10 opacity-70">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.25),transparent_55%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,_rgba(14,165,233,0.2),transparent_45%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,_rgba(236,72,153,0.18),transparent_50%)]" />
+      </div>
       <Header />
       <main className="flex-1">
         <HeroSection />

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -31,38 +31,43 @@ export function AboutSection() {
   ];
 
   return (
-    <section id="about" className="py-24 bg-gradient-to-b from-primary/[0.02] via-background to-secondary/[0.02] relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent"></div>
-      <div className="absolute top-40 left-20 w-64 h-64 bg-gradient-to-br from-primary/10 to-transparent rounded-full blur-3xl"></div>
-      <div className="absolute bottom-40 right-20 w-80 h-80 bg-gradient-to-br from-secondary/10 to-transparent rounded-full blur-3xl"></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center space-y-6 mb-20">
-          <Badge variant="outline" className="w-fit mx-auto px-4 py-2 bg-gradient-to-r from-primary/10 to-secondary/10 border-primary/30 backdrop-blur-sm">
-            <Users className="w-4 h-4 mr-2 text-primary" />
+    <section id="about" className="relative overflow-hidden py-32">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-400/30 to-transparent" />
+        <div className="absolute -left-20 top-32 h-72 w-72 rounded-full bg-cyan-400/10 blur-3xl" />
+        <div className="absolute -right-32 bottom-20 h-[22rem] w-[22rem] rounded-full bg-purple-500/10 blur-3xl" />
+      </div>
+
+      <div className="container relative mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-20 text-center">
+          <Badge className="mx-auto w-fit border-0 bg-white/10 px-4 py-2 text-cyan-200 backdrop-blur">
+            <Users className="mr-2 h-4 w-4 text-cyan-300" />
             About Us
           </Badge>
-          <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary via-foreground to-secondary bg-clip-text text-transparent">
+          <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white md:text-4xl">
             コミュニティの目的
           </h2>
-          <p className="mx-auto max-w-3xl text-lg text-muted-foreground leading-relaxed">
+          <p className="mx-auto mt-4 max-w-3xl text-lg leading-relaxed text-slate-200/80">
             経営と技術の両面を理解するエンジニアが集まり、持続可能な成長戦略を共に考えるコミュニティです。
+            UI/UXの洗練と事業インパクトを両立させるための知見がここに集まります。
           </p>
         </div>
 
-        <div className="grid gap-8 md:grid-cols-2 mb-20">
+        <div className="mb-20 grid gap-8 md:grid-cols-2">
           {goals.map((goal, index) => {
             const Icon = goal.icon;
             return (
-              <Card key={index} className="border-0 shadow-xl bg-gradient-to-br from-card via-card to-muted/10 hover:shadow-2xl transition-all duration-300 group border border-border/20 backdrop-blur-sm">
-                <CardHeader className="text-center space-y-6 pb-6">
-                  <div className={`w-20 h-20 mx-auto bg-gradient-to-br ${goal.gradient} rounded-2xl flex items-center justify-center shadow-lg group-hover:scale-105 transition-transform duration-300 border border-white/20`}>
-                    <Icon className={`w-10 h-10 ${goal.color}`} />
+              <Card
+                key={index}
+                className="group border border-white/10 bg-white/[0.04] shadow-[0_25px_45px_-30px_rgba(15,118,230,0.55)] transition-all duration-300 hover:-translate-y-1 hover:border-cyan-300/60 hover:bg-white/[0.06]"
+              >
+                <CardHeader className="space-y-6 pb-6 text-center">
+                  <div className={`mx-auto flex h-20 w-20 items-center justify-center rounded-2xl border border-white/20 bg-gradient-to-br ${goal.gradient} shadow-lg transition-transform duration-300 group-hover:scale-105`}>
+                    <Icon className={`h-10 w-10 ${goal.color}`} />
                   </div>
                   <div>
-                    <CardTitle className="text-xl font-bold mb-2">{goal.title}</CardTitle>
-                    <CardDescription className="text-base font-medium text-foreground/70">
+                    <CardTitle className="mb-2 text-xl font-semibold text-white">{goal.title}</CardTitle>
+                    <CardDescription className="text-base font-medium text-slate-200/70">
                       {goal.subtitle}
                     </CardDescription>
                   </div>
@@ -71,8 +76,8 @@ export function AboutSection() {
                   <ul className="space-y-4">
                     {goal.items.map((item, itemIndex) => (
                       <li key={itemIndex} className="flex items-start gap-4 group">
-                        <div className={`w-3 h-3 mt-1.5 ${goal.bg} border-2 border-current rounded-full flex-shrink-0 ${goal.color}`} />
-                        <span className="text-foreground/80 leading-relaxed">{item}</span>
+                        <div className={`mt-1.5 h-3 w-3 flex-shrink-0 rounded-full border-2 border-current ${goal.bg} ${goal.color}`} />
+                        <span className="leading-relaxed text-slate-200/80">{item}</span>
                       </li>
                     ))}
                   </ul>
@@ -82,20 +87,21 @@ export function AboutSection() {
           })}
         </div>
 
-        <div className="max-w-4xl mx-auto">
-          <Card className="border-0 bg-gradient-to-r from-primary via-primary/95 to-secondary text-primary-foreground shadow-2xl overflow-hidden relative">
+        <div className="mx-auto max-w-4xl">
+          <Card className="relative overflow-hidden border border-cyan-300/20 bg-gradient-to-r from-cyan-500/20 via-blue-600/25 to-purple-600/20 text-white shadow-[0_30px_60px_-35px_rgba(6,182,212,0.65)]">
             {/* Background pattern */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-white/5 to-transparent"></div>
-            <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-br from-white/10 to-transparent rounded-full blur-3xl transform translate-x-32 -translate-y-32"></div>
-            <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-tr from-white/5 to-transparent rounded-full blur-2xl transform -translate-x-24 translate-y-24"></div>
-            
-            <CardContent className="py-12 px-8 text-center relative z-10">
-              <div className="w-16 h-16 mx-auto mb-6 bg-white/10 rounded-2xl flex items-center justify-center backdrop-blur-sm">
-                <MessageSquare className="w-8 h-8" />
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35),transparent_65%)]" />
+            <div className="pointer-events-none absolute -right-24 top-0 h-64 w-64 rounded-full bg-purple-400/30 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-20 left-0 h-56 w-56 rounded-full bg-cyan-300/25 blur-3xl" />
+
+            <CardContent className="relative z-10 px-8 py-12 text-center">
+              <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-white/20 bg-white/10 backdrop-blur">
+                <MessageSquare className="h-8 w-8 text-white" />
               </div>
-              <h3 className="text-2xl font-bold mb-4">情報交換のハブ</h3>
-              <p className="text-primary-foreground/90 text-lg leading-relaxed max-w-3xl mx-auto">
+              <h3 className="text-2xl font-semibold">情報交換のハブ</h3>
+              <p className="mx-auto mt-4 max-w-3xl text-lg leading-relaxed text-slate-100">
                 技術トレンド、ビジネス戦略、プロダクト開発など、エンジニアとして必要な情報を共有し、共に成長していく場所です。
+                オンライン・オフライン双方でのコラボレーションを通じて、インサイトをすぐにプロダクトへ落とし込みます。
               </p>
             </CardContent>
           </Card>

--- a/src/components/ActivitiesSection.tsx
+++ b/src/components/ActivitiesSection.tsx
@@ -67,33 +67,35 @@ export function ActivitiesSection() {
   ];
 
   return (
-    <section id="activities" className="py-24 relative overflow-hidden">
+    <section id="activities" className="relative overflow-hidden py-32">
       {/* Background decoration */}
-      <div className="absolute inset-0 bg-gradient-to-b from-background via-secondary/[0.02] to-background"></div>
-      <div className="absolute top-20 right-20 w-72 h-72 bg-gradient-to-br from-secondary/10 to-transparent rounded-full blur-3xl"></div>
-      <div className="absolute bottom-40 left-20 w-96 h-96 bg-gradient-to-br from-primary/10 to-transparent rounded-full blur-3xl"></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative">
-        <div className="text-center space-y-6 mb-20">
-          <Badge variant="outline" className="w-fit mx-auto px-4 py-2 bg-gradient-to-r from-primary/10 to-secondary/10 border-primary/30 backdrop-blur-sm">
-            <Calendar className="w-4 h-4 mr-2 text-primary" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.08),transparent_70%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(160deg,rgba(12,74,110,0.35)_0%,rgba(76,29,149,0.25)_45%,transparent_95%)]" />
+      <div className="absolute -left-24 top-24 h-72 w-72 rounded-full bg-cyan-500/10 blur-3xl" />
+      <div className="absolute -right-16 bottom-0 h-96 w-96 rounded-full bg-purple-500/15 blur-3xl" />
+
+      <div className="container relative mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-20 text-center">
+          <Badge className="mx-auto w-fit border-0 bg-white/10 px-4 py-2 text-cyan-200 backdrop-blur">
+            <Calendar className="mr-2 h-4 w-4 text-cyan-300" />
             Activities
           </Badge>
-          <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary via-foreground to-secondary bg-clip-text text-transparent">
+          <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white md:text-4xl">
             活動内容
           </h2>
-          <p className="mx-auto max-w-3xl text-lg text-muted-foreground leading-relaxed">
+          <p className="mx-auto mt-4 max-w-3xl text-lg leading-relaxed text-slate-200/80">
             多様なイベントと情報共有を通じて、エンジニアのスキルアップとネットワーク構築をサポートします。
+            深い洞察とスマートなアウトプットを引き出すプログラムが揃っています。
           </p>
         </div>
 
         {/* Information Sharing Section */}
         <div className="mb-24">
-          <div className="text-center mb-12">
-            <h3 className="text-2xl font-bold mb-4 bg-gradient-to-r from-primary via-primary to-secondary bg-clip-text text-transparent">
+          <div className="mb-12 text-center">
+            <h3 className="text-2xl font-semibold text-white">
               エンジニア同士の情報共有
             </h3>
-            <p className="text-muted-foreground max-w-2xl mx-auto">
+            <p className="mx-auto mt-3 max-w-2xl text-base text-slate-200/70">
               日々の開発で得た知見やツールを共有し、コミュニティ全体のスキル向上を図ります
             </p>
           </div>
@@ -101,15 +103,18 @@ export function ActivitiesSection() {
             {sharingTopics.map((topic, index) => {
               const Icon = topic.icon;
               return (
-                <Card key={index} className="text-center border-0 shadow-lg hover:shadow-xl transition-all duration-300 bg-gradient-to-br from-card via-card to-muted/10 group border border-border/20 backdrop-blur-sm">
+                <Card
+                  key={index}
+                  className="group border border-white/10 bg-white/[0.04] text-center shadow-[0_25px_45px_-30px_rgba(14,165,233,0.5)] transition-all duration-300 hover:-translate-y-1 hover:border-cyan-300/60 hover:bg-white/[0.07]"
+                >
                   <CardHeader className="pb-4">
-                    <div className={`w-16 h-16 mx-auto ${topic.bg} rounded-2xl flex items-center justify-center group-hover:scale-105 transition-transform duration-300 border border-white/20`}>
-                      <Icon className={`w-8 h-8 ${topic.color}`} />
+                    <div className={`mx-auto flex h-16 w-16 items-center justify-center rounded-2xl border border-white/15 ${topic.bg} transition-transform duration-300 group-hover:scale-105`}>
+                      <Icon className={`h-8 w-8 ${topic.color}`} />
                     </div>
-                    <CardTitle className="text-lg">{topic.title}</CardTitle>
+                    <CardTitle className="text-lg text-white">{topic.title}</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <CardDescription className="leading-relaxed">{topic.description}</CardDescription>
+                    <CardDescription className="leading-relaxed text-slate-200/70">{topic.description}</CardDescription>
                   </CardContent>
                 </Card>
               );
@@ -119,11 +124,11 @@ export function ActivitiesSection() {
 
         {/* Events Section */}
         <div>
-          <div className="text-center mb-12">
-            <h3 className="text-2xl font-bold mb-4 bg-gradient-to-r from-primary via-primary to-secondary bg-clip-text text-transparent">
+          <div className="mb-12 text-center">
+            <h3 className="text-2xl font-semibold text-white">
               イベント活動
             </h3>
-            <p className="text-muted-foreground max-w-2xl mx-auto">
+            <p className="mx-auto mt-3 max-w-2xl text-base text-slate-200/70">
               定期的なイベントを通じて、学習と交流の機会を提供します
             </p>
           </div>
@@ -131,45 +136,48 @@ export function ActivitiesSection() {
             {activities.map((activity, index) => {
               const Icon = activity.icon;
               return (
-                <Card key={index} className="overflow-hidden border-0 shadow-xl bg-gradient-to-br from-card via-card to-muted/10 hover:shadow-2xl transition-all duration-500 group border border-border/20 backdrop-blur-sm">
+                <Card
+                  key={index}
+                  className="group overflow-hidden border border-white/10 bg-white/[0.05] shadow-[0_30px_55px_-35px_rgba(76,29,149,0.55)] transition-all duration-500 hover:-translate-y-1.5 hover:border-cyan-300/60 hover:bg-white/[0.08]"
+                >
                   <div className="aspect-video relative overflow-hidden">
                     <ImageWithFallback
                       src={activity.image}
                       alt={activity.title}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
-                    
+
                     {/* Floating icon */}
                     <div className="absolute top-6 left-6">
-                      <div className={`w-12 h-12 bg-gradient-to-br ${activity.gradient} backdrop-blur-xl rounded-xl flex items-center justify-center border border-white/30 shadow-xl`}>
-                        <Icon className="w-6 h-6 text-white" />
+                      <div className={`flex h-12 w-12 items-center justify-center rounded-xl border border-white/30 bg-gradient-to-br ${activity.gradient} backdrop-blur-xl shadow-xl`}>
+                        <Icon className="h-6 w-6 text-white" />
                       </div>
                     </div>
-                    
+
                     {/* Coming soon badge for future events */}
                     {activity.title.includes("予定") && (
                       <div className="absolute top-6 right-6">
-                        <Badge className="bg-gradient-to-r from-orange-500 to-red-500 text-white border-0">
+                        <Badge className="border-0 bg-gradient-to-r from-orange-500 to-red-500 text-white">
                           Coming Soon
                         </Badge>
                       </div>
                     )}
                   </div>
-                  
+
                   <CardHeader className="space-y-3">
-                    <CardTitle className="text-lg leading-tight group-hover:text-primary transition-colors">
+                    <CardTitle className="text-lg leading-tight text-white transition-colors group-hover:text-cyan-200">
                       {activity.title}
                     </CardTitle>
-                    <CardDescription className="leading-relaxed text-base">
+                    <CardDescription className="text-base leading-relaxed text-slate-200/70">
                       {activity.description}
                     </CardDescription>
                   </CardHeader>
-                  
+
                   <CardContent className="pt-0">
-                    <div className="flex items-center text-primary hover:text-primary/80 transition-colors cursor-pointer">
+                    <div className="flex items-center cursor-pointer text-cyan-300 transition-colors hover:text-cyan-200">
                       <span className="text-sm font-medium">詳細を見る</span>
-                      <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </div>
                   </CardContent>
                 </Card>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,30 +19,32 @@ export function Footer() {
   };
 
   return (
-    <footer className="border-t border-border/40 bg-gradient-to-b from-muted/20 to-muted/40 relative overflow-hidden">
+    <footer className="relative overflow-hidden border-t border-white/10 bg-[#040712]">
       {/* Background decoration */}
-      <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-border to-transparent"></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-16 relative">
-        <div className="grid gap-8 md:grid-cols-4">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-400/40 to-transparent" />
+      <div className="pointer-events-none absolute -left-20 top-10 h-56 w-56 rounded-full bg-cyan-500/10 blur-3xl" />
+      <div className="pointer-events-none absolute -right-16 bottom-0 h-64 w-64 rounded-full bg-purple-500/10 blur-3xl" />
+
+      <div className="container relative mx-auto px-4 py-12 sm:px-6 md:py-16 lg:px-8">
+        <div className="grid gap-10 md:grid-cols-4">
           <div className="space-y-4">
             <div className="flex items-center space-x-3">
               <div className="relative">
                 <img src={DevelopersGuildIcon} alt="GLOBIS Tech Guild" className="h-7 w-7" />
-                <div className="absolute -inset-1 bg-gradient-to-r from-primary/20 to-secondary/20 rounded-lg blur opacity-75"></div>
+                <div className="absolute -inset-1 rounded-lg bg-gradient-to-r from-cyan-400/30 via-blue-500/30 to-purple-500/30 blur opacity-80"></div>
               </div>
-              <span className="font-semibold text-lg bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-white via-cyan-100 to-white/80 bg-clip-text text-lg font-semibold tracking-wide text-transparent">
                 GLOBIS Tech Guild
               </span>
             </div>
-            <p className="text-sm text-muted-foreground leading-relaxed">
+            <p className="text-sm leading-relaxed text-slate-300/80">
               MBA × エンジニアのコミュニティ
             </p>
           </div>
-          
+
           <div className="space-y-4">
-            <h4 className="font-semibold text-foreground">ナビゲーション</h4>
-            <ul className="space-y-3 text-sm">
+            <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-200/90">ナビゲーション</h4>
+            <ul className="space-y-3 text-sm text-slate-300/70">
               {[
                 { href: "#about", label: "About" },
                 { href: "#activities", label: "Activities" }
@@ -51,7 +53,7 @@ export function Footer() {
                   <a
                     href={item.href}
                     onClick={(e) => handleSmoothScroll(e, item.href)}
-                    className="text-muted-foreground hover:text-primary transition-all duration-200 hover:translate-x-1 inline-block cursor-pointer"
+                    className="inline-block cursor-pointer transition-all duration-200 hover:translate-x-1 hover:text-cyan-200"
                   >
                     {item.label}
                   </a>
@@ -59,33 +61,34 @@ export function Footer() {
               ))}
             </ul>
           </div>
-          
+
           <div className="space-y-4">
-            <h4 className="font-semibold text-foreground">活動内容</h4>
-            <ul className="space-y-3 text-sm">
+            <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-200/90">活動内容</h4>
+            <ul className="space-y-3 text-sm text-slate-300/70">
               {[
                 "LTイベント",
-                "パネルディスカッション", 
+                "パネルディスカッション",
                 "ワークショップ",
                 "プロダクト開発"
               ].map((activity) => (
-                <li key={activity} className="text-muted-foreground">
+                <li key={activity} className="transition-colors hover:text-cyan-200">
                   {activity}
                 </li>
               ))}
             </ul>
           </div>
-          
+
           <div className="space-y-4">
-            <h4 className="font-semibold text-foreground">コミュニティ</h4>
-            <p className="text-sm text-muted-foreground leading-relaxed">
+            <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-200/90">コミュニティ</h4>
+            <p className="text-sm leading-relaxed text-slate-300/80">
               経営視点を持つエンジニアが集まり、共に成長するコミュニティです。
+              次のプロダクト体験を共にデザインしましょう。
             </p>
           </div>
         </div>
-        
-        <div className="mt-12 pt-8 border-t border-border/30 text-center">
-          <p className="text-sm text-muted-foreground">
+
+        <div className="mt-12 border-t border-white/10 pt-8 text-center">
+          <p className="text-sm text-slate-400">
             © 2025 GLOBIS Tech Guild. All rights reserved.
           </p>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,12 @@
 import { Button } from "./ui/button";
-import { Menu, X } from "lucide-react";
+import { Menu, Sparkles, X } from "lucide-react";
 import { useState, type MouseEvent } from "react";
 import DevelopersGuildIcon from "../assets/DevelopersGuild.svg";
 
 export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
-  const handleSmoothScroll = (e: MouseEvent<HTMLAnchorElement>, href: string) => {
-    e.preventDefault();
+  const scrollToSection = (href: string) => {
     const targetId = href.replace('#', '');
     const element = document.getElementById(targetId);
     if (element) {
@@ -20,11 +19,17 @@ export function Header() {
         behavior: 'smooth'
       });
     }
+  };
+
+  const handleSmoothScroll = (e: MouseEvent<HTMLAnchorElement>, href: string) => {
+    e.preventDefault();
+    scrollToSection(href);
     setMobileMenuOpen(false); // モバイルメニューを閉じる
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-[#05060f]/80 backdrop-blur-xl">
+      <div className="absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-cyan-400/40 to-transparent" />
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
@@ -32,9 +37,9 @@ export function Header() {
             <a className="flex items-center space-x-3" href="/">
               <div className="relative">
                 <img src={DevelopersGuildIcon} alt="GLOBIS Tech Guild" className="h-8 w-8" />
-                <div className="absolute -inset-1 bg-gradient-to-r from-primary/20 to-secondary/20 rounded-lg blur opacity-75"></div>
+                <div className="absolute -inset-1 rounded-lg bg-gradient-to-r from-cyan-400/40 via-blue-500/40 to-purple-500/40 blur opacity-80"></div>
               </div>
-              <span className="font-semibold text-lg bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
+              <span className="font-semibold text-lg tracking-wide bg-gradient-to-r from-white via-cyan-100 to-white/80 bg-clip-text text-transparent">
                 GLOBIS Tech Guild
               </span>
             </a>
@@ -50,12 +55,25 @@ export function Header() {
                 key={item.href}
                 href={item.href}
                 onClick={(e) => handleSmoothScroll(e, item.href)}
-                className="px-4 py-2 rounded-lg text-sm font-medium text-foreground/70 hover:text-foreground hover:bg-accent/50 transition-all duration-200 cursor-pointer"
+                className="px-4 py-2 rounded-full text-sm font-medium text-slate-300 hover:text-white hover:bg-white/10 transition-all duration-200 cursor-pointer"
               >
                 {item.label}
               </a>
             ))}
           </nav>
+
+          <div className="hidden md:flex items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-300">
+              <Sparkles className="h-3.5 w-3.5 text-cyan-300" />
+              <span>Next meetup in planning</span>
+            </div>
+            <Button
+              className="rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-blue-500 px-5 py-2 text-sm font-semibold text-slate-900 shadow-[0_10px_40px_-15px_rgba(56,189,248,0.8)] hover:from-cyan-300 hover:via-sky-400 hover:to-blue-400"
+              onClick={() => scrollToSection('#activities')}
+            >
+              Join the Guild
+            </Button>
+          </div>
 
           {/* Mobile menu button */}
           <div className="md:hidden">
@@ -76,7 +94,7 @@ export function Header() {
         {/* Mobile Navigation */}
         {mobileMenuOpen && (
           <div className="md:hidden">
-            <div className="px-2 pt-2 pb-3 space-y-1 border-t border-border/40 bg-background/95 backdrop-blur-sm">
+            <div className="space-y-1 border-t border-white/10 bg-[#05060f]/95 px-2 pt-2 pb-4 backdrop-blur-xl">
               {[
                 { href: "#about", label: "About" },
                 { href: "#activities", label: "Activities" }
@@ -84,12 +102,21 @@ export function Header() {
                 <a
                   key={item.href}
                   href={item.href}
-                  className="block px-3 py-2 rounded-md text-base font-medium text-foreground/70 hover:text-foreground hover:bg-accent/50 transition-colors cursor-pointer"
+                  className="block rounded-lg px-3 py-2 text-base font-medium text-slate-300 transition-colors hover:bg-white/10 hover:text-white cursor-pointer"
                   onClick={(e) => handleSmoothScroll(e, item.href)}
                 >
                   {item.label}
                 </a>
               ))}
+              <Button
+                className="mt-2 w-full rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-blue-500 text-slate-900"
+                onClick={() => {
+                  scrollToSection('#activities');
+                  setMobileMenuOpen(false);
+                }}
+              >
+                Join the Guild
+              </Button>
             </div>
           </div>
         )}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,15 +1,111 @@
 import { ImageWithFallback } from "./figma/ImageWithFallback";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Cpu, Rocket, ShieldCheck } from "lucide-react";
 import HeroSectionimg from "../assets/HeroSection.svg";
+
+const highlights = [
+  {
+    icon: Cpu,
+    title: "プロダクト設計",
+    description: "実践的な開発知見を交換"
+  },
+  {
+    icon: ShieldCheck,
+    title: "MBA視点の戦略",
+    description: "事業づくりに効く意思決定"
+  },
+  {
+    icon: Rocket,
+    title: "共同プロジェクト",
+    description: "一歩先のプロダクトを共創"
+  }
+];
 
 export function HeroSection() {
   return (
-    <section className="relative h-screen w-full overflow-hidden bg-gray-900">
+    <section className="relative flex min-h-screen items-center overflow-hidden">
       <ImageWithFallback
         src={HeroSectionimg}
         alt="Modern tech workspace"
-        className="h-full w-full object-cover"
+        className="absolute inset-0 h-full w-full object-cover"
         loading="eager"
       />
+      <div className="absolute inset-0 bg-gradient-to-r from-[#05060f]/95 via-[#05060f]/85 to-[#0a1f33]/35" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.25),transparent_55%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_30%,_rgba(59,130,246,0.35),transparent_60%)]" />
+
+      <div className="container relative z-10 mx-auto flex flex-col gap-14 px-4 py-24 sm:px-6 lg:flex-row lg:items-center lg:gap-20 lg:px-8">
+        <div className="max-w-2xl space-y-8">
+          <Badge className="border-0 bg-white/10 text-cyan-200 backdrop-blur">
+            <span className="text-xs font-semibold tracking-[0.3em] uppercase">GLOBIS TECH GUILD</span>
+          </Badge>
+          <div className="space-y-6">
+            <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+              MBA視点で未来を描く
+              <span className="block bg-gradient-to-r from-cyan-200 via-blue-200 to-purple-200 bg-clip-text text-transparent">
+                "いけてる"プロダクトを共創するコミュニティ
+              </span>
+            </h1>
+            <p className="text-lg text-slate-200/90 sm:text-xl">
+              ビジネスとテクノロジーが交差する最前線で、戦略設計から開発実装までを横断的に磨き合うギルドです。
+              洗練されたアウトプットを追求する仲間と共に、次のプロダクト体験をデザインしませんか？
+            </p>
+          </div>
+
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+            <Button
+              className="rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-blue-500 px-8 py-6 text-base font-semibold text-slate-900 shadow-[0_20px_45px_-20px_rgba(56,189,248,0.9)] transition-transform hover:-translate-y-0.5"
+              onClick={() => document.getElementById('activities')?.scrollIntoView({ behavior: 'smooth' })}
+            >
+              コミュニティに参加する
+            </Button>
+            <Button
+              variant="outline"
+              className="rounded-full border-white/40 bg-white/5 px-8 py-6 text-base text-white backdrop-blur hover:bg-white/10"
+              onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
+            >
+              活動内容を見る
+            </Button>
+          </div>
+
+          <div className="grid gap-4 pt-6 sm:grid-cols-3">
+            {highlights.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="group rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl transition-colors hover:border-cyan-300/60 hover:bg-white/10"
+              >
+                <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-400/20 via-blue-500/20 to-purple-500/20 text-cyan-200">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <h3 className="text-sm font-semibold text-white/90">{title}</h3>
+                <p className="mt-2 text-sm text-slate-200/70">{description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative hidden w-full max-w-md self-stretch lg:block">
+          <div className="absolute -left-10 top-12 h-28 w-28 rounded-3xl bg-gradient-to-br from-cyan-400/60 to-blue-500/40 blur-2xl" />
+          <div className="absolute -right-8 bottom-10 h-24 w-24 rounded-full bg-gradient-to-br from-purple-400/50 to-pink-500/40 blur-3xl" />
+          <div className="relative rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-2xl">
+            <div className="space-y-6">
+              <div>
+                <p className="text-xs uppercase tracking-[0.25em] text-cyan-200/80">Insights</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">最新のナレッジが集まる</h3>
+              </div>
+              <p className="text-sm leading-relaxed text-slate-200/80">
+                SaaS開発、AI活用、事業グロースなど、先端領域の議論が日常的に生まれています。ビジュアル・UI観点のフィードバックも手厚く、質の高いアウトプットを目指す人に最適です。
+              </p>
+              <div className="flex flex-wrap gap-3 text-xs text-slate-200/70">
+                <span className="rounded-full border border-cyan-300/40 bg-cyan-300/10 px-3 py-1">Design Review</span>
+                <span className="rounded-full border border-blue-400/40 bg-blue-400/10 px-3 py-1">Tech Strategy</span>
+                <span className="rounded-full border border-purple-400/40 bg-purple-400/10 px-3 py-1">Growth Hack</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- update the global layout shell with layered gradients that mirror the hero artwork and set a darker tech-forward palette
- redesign the hero content with messaging, CTAs, and highlight cards layered over the illustration for a polished IT aesthetic
- refresh the about, activities, and footer sections with glassmorphism-inspired cards and gradients to match the new tone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5e31d4050832c991a341b8d8f0df5