### PR TITLE
Align about and activities sections with hero aesthetic

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { Target, Rocket, Users, MessageSquare } from "lucide-react";
+import { ImageWithFallback } from "./figma/ImageWithFallback";
+import HeroSectionimg from "../assets/HeroSection.svg";
 
 export function AboutSection() {
   const goals = [
@@ -8,95 +10,103 @@ export function AboutSection() {
       icon: Target,
       title: "コミュニティの価値",
       subtitle: "MBA × エンジニアの知見共有",
-      items: [
-        "経営×創造者の情報交換",
-        "最新情報が飛び交う場"
-      ],
-      color: "text-blue-600",
-      gradient: "from-blue-500/10 to-blue-600/5",
-      bg: "bg-blue-500/5"
+      items: ["経営×創造者の情報交換", "最新情報が飛び交う場"],
+      accent: "from-sky-400/60 via-sky-300/40 to-transparent"
     },
     {
       icon: Rocket,
       title: "目指すもの",
       subtitle: "継続的な成長とイノベーション",
-      items: [
-        "プロダクト開発スキルの向上",
-        "持続可能な開発体制"
-      ],
-      color: "text-emerald-600",
-      gradient: "from-emerald-500/10 to-emerald-600/5",
-      bg: "bg-emerald-500/5"
+      items: ["プロダクト開発スキルの向上", "持続可能な開発体制"],
+      accent: "from-emerald-400/60 via-emerald-300/40 to-transparent"
     }
   ];
 
   return (
-    <section id="about" className="py-24 bg-gradient-to-b from-primary/[0.02] via-background to-secondary/[0.02] relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent"></div>
-      <div className="absolute top-40 left-20 w-64 h-64 bg-gradient-to-br from-primary/10 to-transparent rounded-full blur-3xl"></div>
-      <div className="absolute bottom-40 right-20 w-80 h-80 bg-gradient-to-br from-secondary/10 to-transparent rounded-full blur-3xl"></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center space-y-6 mb-20">
-          <Badge variant="outline" className="w-fit mx-auto px-4 py-2 bg-gradient-to-r from-primary/10 to-secondary/10 border-primary/30 backdrop-blur-sm">
-            <Users className="w-4 h-4 mr-2 text-primary" />
-            About Us
-          </Badge>
-          <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary via-foreground to-secondary bg-clip-text text-transparent">
-            コミュニティの目的
-          </h2>
-          <p className="mx-auto max-w-3xl text-lg text-muted-foreground leading-relaxed">
-            経営と技術の両面を理解するエンジニアが集まり、持続可能な成長戦略を共に考えるコミュニティです。
-          </p>
+    <section id="about" className="relative py-24 text-slate-100 overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <ImageWithFallback
+          src={HeroSectionimg}
+          alt="Ambient workspace texture"
+          className="h-full w-full object-cover opacity-30"
+          loading="lazy"
+        />
+        <div className="absolute inset-0 bg-slate-950/85 backdrop-blur-md" />
+        <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-slate-950 via-slate-950/80 to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-slate-950 via-slate-950/80 to-transparent" />
+      </div>
+
+      <div className="container mx-auto px-4 sm:px-6 lg:px-10">
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center">
+          <div className="lg:w-2/5 space-y-6">
+            <Badge className="w-fit bg-white/10 text-slate-100 border-white/20 backdrop-blur">
+              <Users className="w-4 h-4 mr-2 text-sky-300" />
+              About Us
+            </Badge>
+            <h2 className="text-3xl md:text-4xl font-semibold leading-tight">
+              コミュニティの目的
+            </h2>
+            <p className="text-base md:text-lg text-slate-300 leading-relaxed">
+              経営と技術の両面を理解するエンジニアが集まり、持続可能な成長戦略を共に考えるコミュニティです。
+              ビジュアルのトーンを揃えた落ち着いた空間で、深いインサイトと実践知を共有します。
+            </p>
+          </div>
+
+          <div className="lg:w-3/5 grid gap-6 md:grid-cols-2">
+            {goals.map((goal, index) => {
+              const Icon = goal.icon;
+              return (
+                <Card
+                  key={index}
+                  className="relative overflow-hidden border border-white/10 bg-white/5 text-slate-100 backdrop-blur-xl"
+                >
+                  <div className={`absolute inset-x-6 top-0 h-px bg-gradient-to-r ${goal.accent}`} />
+                  <CardHeader className="space-y-4 pb-0">
+                    <div className="flex items-center gap-4">
+                      <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10">
+                        <Icon className="h-6 w-6 text-white" />
+                      </span>
+                      <div>
+                        <CardTitle className="text-lg font-medium">{goal.title}</CardTitle>
+                        <CardDescription className="text-slate-300 text-sm">
+                          {goal.subtitle}
+                        </CardDescription>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="pt-6">
+                    <ul className="space-y-4">
+                      {goal.items.map((item, itemIndex) => (
+                        <li key={itemIndex} className="flex items-start gap-3 text-sm text-slate-200">
+                          <div className="mt-1 h-2 w-2 rounded-full bg-white/60" />
+                          <span className="leading-relaxed">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
         </div>
 
-        <div className="grid gap-8 md:grid-cols-2 mb-20">
-          {goals.map((goal, index) => {
-            const Icon = goal.icon;
-            return (
-              <Card key={index} className="border-0 shadow-xl bg-gradient-to-br from-card via-card to-muted/10 hover:shadow-2xl transition-all duration-300 group border border-border/20 backdrop-blur-sm">
-                <CardHeader className="text-center space-y-6 pb-6">
-                  <div className={`w-20 h-20 mx-auto bg-gradient-to-br ${goal.gradient} rounded-2xl flex items-center justify-center shadow-lg group-hover:scale-105 transition-transform duration-300 border border-white/20`}>
-                    <Icon className={`w-10 h-10 ${goal.color}`} />
-                  </div>
-                  <div>
-                    <CardTitle className="text-xl font-bold mb-2">{goal.title}</CardTitle>
-                    <CardDescription className="text-base font-medium text-foreground/70">
-                      {goal.subtitle}
-                    </CardDescription>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4 px-8 pb-8">
-                  <ul className="space-y-4">
-                    {goal.items.map((item, itemIndex) => (
-                      <li key={itemIndex} className="flex items-start gap-4 group">
-                        <div className={`w-3 h-3 mt-1.5 ${goal.bg} border-2 border-current rounded-full flex-shrink-0 ${goal.color}`} />
-                        <span className="text-foreground/80 leading-relaxed">{item}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
+        <div className="mt-16">
+          <Card className="relative overflow-hidden border border-white/10 bg-white/5 text-slate-100 backdrop-blur-xl">
+            <div className="absolute inset-0 bg-gradient-to-br from-white/5 via-white/0 to-white/5" />
+            <div className="absolute -top-20 right-16 h-48 w-48 rounded-full bg-sky-400/10 blur-3xl" />
+            <div className="absolute -bottom-24 left-10 h-56 w-56 rounded-full bg-emerald-400/10 blur-3xl" />
 
-        <div className="max-w-4xl mx-auto">
-          <Card className="border-0 bg-gradient-to-r from-primary via-primary/95 to-secondary text-primary-foreground shadow-2xl overflow-hidden relative">
-            {/* Background pattern */}
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-white/5 to-transparent"></div>
-            <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-br from-white/10 to-transparent rounded-full blur-3xl transform translate-x-32 -translate-y-32"></div>
-            <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-tr from-white/5 to-transparent rounded-full blur-2xl transform -translate-x-24 translate-y-24"></div>
-            
-            <CardContent className="py-12 px-8 text-center relative z-10">
-              <div className="w-16 h-16 mx-auto mb-6 bg-white/10 rounded-2xl flex items-center justify-center backdrop-blur-sm">
-                <MessageSquare className="w-8 h-8" />
+            <CardContent className="relative z-10 flex flex-col items-center gap-6 py-12 text-center">
+              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/10">
+                <MessageSquare className="h-8 w-8 text-white" />
               </div>
-              <h3 className="text-2xl font-bold mb-4">情報交換のハブ</h3>
-              <p className="text-primary-foreground/90 text-lg leading-relaxed max-w-3xl mx-auto">
-                技術トレンド、ビジネス戦略、プロダクト開発など、エンジニアとして必要な情報を共有し、共に成長していく場所です。
-              </p>
+              <div className="space-y-3 max-w-3xl">
+                <h3 className="text-2xl font-semibold">情報交換のハブ</h3>
+                <p className="text-slate-300 leading-relaxed">
+                  技術トレンド、ビジネス戦略、プロダクト開発など、エンジニアとして必要な情報を共有し、
+                  共に成長していく場所です。知見が交差する瞬間を大切にしながら、価値の高いコラボレーションを生み出します。
+                </p>
+              </div>
             </CardContent>
           </Card>
         </div>

--- a/src/components/ActivitiesSection.tsx
+++ b/src/components/ActivitiesSection.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/
 import { Badge } from "./ui/badge";
 import { Calendar, Mic, Users, Wrench, Code, Share2, TrendingUp, UserCheck, ArrowRight } from "lucide-react";
 import { ImageWithFallback } from "./figma/ImageWithFallback";
+import HeroSectionimg from "../assets/HeroSection.svg";
 
 export function ActivitiesSection() {
   const activities = [
@@ -9,107 +10,112 @@ export function ActivitiesSection() {
       icon: Mic,
       title: "LT（ライトニングトーク）イベント",
       description: "5分間の短時間で技術的な発見や学びを共有",
-      image: "https://images.unsplash.com/photo-1559146820-a75deba24b58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwcmVzZW50YXRpb24lMjBzbGlkZXMlMjBzY3JlZW4lMjB0ZWNofGVufDF8fHx8MTc1OTI1NDA5NHww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
-      gradient: "from-orange-500/10 to-red-500/10"
+      image:
+        "https://images.unsplash.com/photo-1559146820-a75deba24b58?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwcmVzZW50YXRpb24lMjBzbGlkZXMlMjBzY3JlZW4lMjB0ZWNofGVufDF8fHx8MTc1OTI1NDA5NHww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+      tint: "from-orange-500/20 via-rose-500/20 to-transparent"
     },
     {
       icon: Users,
       title: "パネルディスカッション",
       description: "業界のエキスパートによる深い議論と知識共有",
-      image: "https://images.unsplash.com/photo-1697059361461-b81d0e98c3af?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25mZXJlbmNlJTIwcm9vbSUyMGRpc2N1c3Npb24lMjBzZXR1cHxlbnwxfHx8fDE3NTkyNTQwOTh8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
-      gradient: "from-blue-500/10 to-purple-500/10"
+      image:
+        "https://images.unsplash.com/photo-1697059361461-b81d0e98c3af?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25mZXJlbmNlJTIwcm9vbSUyMGRpc2N1c3Npb24lMjBzZXR1cHxlbnwxfHx8fDE3NTkyNTQwOTh8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+      tint: "from-blue-500/20 via-indigo-500/20 to-transparent"
     },
     {
       icon: Wrench,
       title: "ワークイベント",
       description: "実践的なスキル向上のためのハンズオンワークショップ",
-      image: "https://images.unsplash.com/photo-1554306274-f23873d9a26c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb2RpbmclMjB3b3Jrc2hvcCUyMHByb2dyYW1taW5nJTIwc2V0dXB8ZW58MXx8fHwxNzU5MjU0MTkwfDA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
-      gradient: "from-green-500/10 to-emerald-500/10"
+      image:
+        "https://images.unsplash.com/photo-1554306274-f23873d9a26c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb2RpbmclMjB3b3Jrc2hvcCUyMHByb2dyYW1taW5nJTIwc2V0dXB8ZW58MXx8fHwxNzU5MjU0MTkwfDA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+      tint: "from-emerald-500/20 via-teal-500/20 to-transparent"
     },
     {
       icon: Code,
       title: "プロダクト開発（予定）",
       description: "コミュニティメンバーによる共同プロダクト開発",
-      image: "https://images.unsplash.com/photo-1625459201773-9b2386f53ca2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzb2Z0d2FyZSUyMGRldmVsb3BtZW50JTIwY29tcHV0ZXIlMjBjb2RlfGVufDF8fHx8MTc1OTI1NDE5M3ww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
-      gradient: "from-purple-500/10 to-pink-500/10"
+      image:
+        "https://images.unsplash.com/photo-1625459201773-9b2386f53ca2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzb2Z0d2FyZSUyMGRldmVsb3BtZW50JTIwY29tcHV0ZXIlMjBjb2RlfGVufDF8fHx8MTc1OTI1NDE5M3ww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral",
+      tint: "from-purple-500/20 via-fuchsia-500/20 to-transparent"
     }
   ];
 
   const sharingTopics = [
-    { 
-      icon: Share2, 
-      title: "ツールシェア", 
-      description: "開発効率を上げるツールの共有",
-      color: "text-blue-600",
-      bg: "bg-blue-500/10"
+    {
+      icon: Share2,
+      title: "ツールシェア",
+      description: "開発効率を上げるツールの共有"
     },
-    { 
-      icon: Code, 
-      title: "プロダクト開発ノウハウ", 
-      description: "実践的な開発手法の共有",
-      color: "text-green-600",
-      bg: "bg-green-500/10"
+    {
+      icon: Code,
+      title: "プロダクト開発ノウハウ",
+      description: "実践的な開発手法の共有"
     },
-    { 
-      icon: TrendingUp, 
-      title: "グロースハック", 
-      description: "プロダクト成長のための戦略",
-      color: "text-purple-600",
-      bg: "bg-purple-500/10"
+    {
+      icon: TrendingUp,
+      title: "グロースハック",
+      description: "プロダクト成長のための戦略"
     },
-    { 
-      icon: UserCheck, 
-      title: "チームマネジメント", 
-      description: "効果的なチーム運営手法",
-      color: "text-orange-600",
-      bg: "bg-orange-500/10"
+    {
+      icon: UserCheck,
+      title: "チームマネジメント",
+      description: "効果的なチーム運営手法"
     }
   ];
 
   return (
-    <section id="activities" className="py-24 relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute inset-0 bg-gradient-to-b from-background via-secondary/[0.02] to-background"></div>
-      <div className="absolute top-20 right-20 w-72 h-72 bg-gradient-to-br from-secondary/10 to-transparent rounded-full blur-3xl"></div>
-      <div className="absolute bottom-40 left-20 w-96 h-96 bg-gradient-to-br from-primary/10 to-transparent rounded-full blur-3xl"></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative">
-        <div className="text-center space-y-6 mb-20">
-          <Badge variant="outline" className="w-fit mx-auto px-4 py-2 bg-gradient-to-r from-primary/10 to-secondary/10 border-primary/30 backdrop-blur-sm">
-            <Calendar className="w-4 h-4 mr-2 text-primary" />
+    <section id="activities" className="relative py-24 text-slate-100 overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <ImageWithFallback
+          src={HeroSectionimg}
+          alt="Workspace backdrop"
+          className="h-full w-full object-cover opacity-20"
+          loading="lazy"
+        />
+        <div className="absolute inset-0 bg-slate-950/90 backdrop-blur-xl" />
+        <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-slate-950 via-slate-950/80 to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 h-64 bg-gradient-to-t from-slate-950 via-slate-950/80 to-transparent" />
+      </div>
+
+      <div className="container mx-auto px-4 sm:px-6 lg:px-10 relative">
+        <div className="text-center space-y-6 mb-16">
+          <Badge className="w-fit mx-auto bg-white/10 text-slate-100 border-white/20 backdrop-blur">
+            <Calendar className="w-4 h-4 mr-2 text-sky-300" />
             Activities
           </Badge>
-          <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary via-foreground to-secondary bg-clip-text text-transparent">
-            活動内容
-          </h2>
-          <p className="mx-auto max-w-3xl text-lg text-muted-foreground leading-relaxed">
+          <h2 className="text-3xl md:text-4xl font-semibold">活動内容</h2>
+          <p className="mx-auto max-w-3xl text-base md:text-lg text-slate-300 leading-relaxed">
             多様なイベントと情報共有を通じて、エンジニアのスキルアップとネットワーク構築をサポートします。
+            スタジオライティングのような落ち着いたトーンで、集中した学びと交流を実現します。
           </p>
         </div>
 
-        {/* Information Sharing Section */}
-        <div className="mb-24">
+        <div className="mb-20">
           <div className="text-center mb-12">
-            <h3 className="text-2xl font-bold mb-4 bg-gradient-to-r from-primary via-primary to-secondary bg-clip-text text-transparent">
-              エンジニア同士の情報共有
-            </h3>
-            <p className="text-muted-foreground max-w-2xl mx-auto">
-              日々の開発で得た知見やツールを共有し、コミュニティ全体のスキル向上を図ります
+            <h3 className="text-2xl font-semibold mb-4">エンジニア同士の情報共有</h3>
+            <p className="text-slate-300 max-w-2xl mx-auto">
+              日々の開発で得た知見やツールを共有し、コミュニティ全体のスキル向上を図ります。
+              シックなビジュアルで落ち着いてインサイトを交換できるスペースです。
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
             {sharingTopics.map((topic, index) => {
               const Icon = topic.icon;
               return (
-                <Card key={index} className="text-center border-0 shadow-lg hover:shadow-xl transition-all duration-300 bg-gradient-to-br from-card via-card to-muted/10 group border border-border/20 backdrop-blur-sm">
-                  <CardHeader className="pb-4">
-                    <div className={`w-16 h-16 mx-auto ${topic.bg} rounded-2xl flex items-center justify-center group-hover:scale-105 transition-transform duration-300 border border-white/20`}>
-                      <Icon className={`w-8 h-8 ${topic.color}`} />
-                    </div>
-                    <CardTitle className="text-lg">{topic.title}</CardTitle>
+                <Card
+                  key={index}
+                  className="border border-white/10 bg-white/5 text-slate-100 backdrop-blur-xl transition-transform duration-300 hover:-translate-y-1"
+                >
+                  <CardHeader className="space-y-4 text-center">
+                    <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-xl bg-white/10">
+                      <Icon className="h-7 w-7 text-white" />
+                    </span>
+                    <CardTitle className="text-base md:text-lg font-medium">{topic.title}</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <CardDescription className="leading-relaxed">{topic.description}</CardDescription>
+                    <CardDescription className="text-slate-300 leading-relaxed">
+                      {topic.description}
+                    </CardDescription>
                   </CardContent>
                 </Card>
               );
@@ -117,59 +123,60 @@ export function ActivitiesSection() {
           </div>
         </div>
 
-        {/* Events Section */}
-        <div>
-          <div className="text-center mb-12">
-            <h3 className="text-2xl font-bold mb-4 bg-gradient-to-r from-primary via-primary to-secondary bg-clip-text text-transparent">
-              イベント活動
-            </h3>
-            <p className="text-muted-foreground max-w-2xl mx-auto">
-              定期的なイベントを通じて、学習と交流の機会を提供します
+        <div className="space-y-10">
+          <div className="text-center">
+            <h3 className="text-2xl font-semibold mb-4">イベント活動</h3>
+            <p className="text-slate-300 max-w-2xl mx-auto">
+              定期的なイベントを通じて、学習と交流の機会を提供します。写真の光と影のコントラストが、
+              HeroSectionの世界観と連続性を持たせています。
             </p>
           </div>
           <div className="grid gap-8 md:grid-cols-2">
             {activities.map((activity, index) => {
               const Icon = activity.icon;
               return (
-                <Card key={index} className="overflow-hidden border-0 shadow-xl bg-gradient-to-br from-card via-card to-muted/10 hover:shadow-2xl transition-all duration-500 group border border-border/20 backdrop-blur-sm">
-                  <div className="aspect-video relative overflow-hidden">
+                <Card
+                  key={index}
+                  className="overflow-hidden border border-white/10 bg-white/5 text-slate-100 backdrop-blur-xl transition-transform duration-500 hover:-translate-y-1"
+                >
+                  <div className="relative aspect-video overflow-hidden">
                     <ImageWithFallback
                       src={activity.image}
                       alt={activity.title}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                      className="h-full w-full object-cover"
                     />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
-                    
-                    {/* Floating icon */}
+                    <div className={`absolute inset-0 bg-gradient-to-br ${activity.tint}`} />
+                    <div className="absolute inset-0 bg-slate-950/40" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-950/70 via-slate-950/20 to-transparent" />
+
                     <div className="absolute top-6 left-6">
-                      <div className={`w-12 h-12 bg-gradient-to-br ${activity.gradient} backdrop-blur-xl rounded-xl flex items-center justify-center border border-white/30 shadow-xl`}>
-                        <Icon className="w-6 h-6 text-white" />
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/10">
+                        <Icon className="h-6 w-6 text-white" />
                       </div>
                     </div>
-                    
-                    {/* Coming soon badge for future events */}
+
                     {activity.title.includes("予定") && (
                       <div className="absolute top-6 right-6">
-                        <Badge className="bg-gradient-to-r from-orange-500 to-red-500 text-white border-0">
+                        <Badge className="bg-white/15 text-white border border-white/30 backdrop-blur">
                           Coming Soon
                         </Badge>
                       </div>
                     )}
                   </div>
-                  
+
                   <CardHeader className="space-y-3">
-                    <CardTitle className="text-lg leading-tight group-hover:text-primary transition-colors">
+                    <CardTitle className="text-lg font-medium leading-tight">
                       {activity.title}
                     </CardTitle>
-                    <CardDescription className="leading-relaxed text-base">
+                    <CardDescription className="text-slate-300 leading-relaxed">
                       {activity.description}
                     </CardDescription>
                   </CardHeader>
-                  
+
                   <CardContent className="pt-0">
-                    <div className="flex items-center text-primary hover:text-primary/80 transition-colors cursor-pointer">
+                    <div className="group flex items-center text-sky-300 hover:text-sky-200 transition-colors cursor-pointer">
                       <span className="text-sm font-medium">詳細を見る</span>
-                      <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+                      <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
                     </div>
                   </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary
- restyle the about section with a dark, photographic backdrop and glassmorphism accents to match the hero imagery
- refresh activity highlights with cohesive overlays, tinted event cards, and soft lighting treatments that echo the hero section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5e53ede00832cb62e34ef105afbaf